### PR TITLE
Add support for Cognitive Services Bing Search API v5 (Preview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 [![Build Status](https://travis-ci.org/ClaudeBot/hubot-search.svg)](https://travis-ci.org/ClaudeBot/hubot-search)
 [![devDependency Status](https://david-dm.org/ClaudeBot/hubot-search/dev-status.svg)](https://david-dm.org/ClaudeBot/hubot-search#info=devDependencies)
 
-An extendable Hubot script for querying several search engine services: [Google Custom Search][gcse], and [Bing Search API][bse].
+An extendable Hubot script for querying several search engine services: [Google Custom Search][googlesearch], [Azure Marketplace - Bing Search API v2][azurebing], and [Microsoft Cognitive Services - Bing Search API v5][cognitivebing].
 
 See [`src/search.coffee`](src/search.coffee) for full documentation.
+
+---
+
+**Attention:** Azure Marketplace _"Bing Search"_ and _"Bing Search Web Results Only"_ API (v2) [offerings][azurebing] will end of life on **December 15, 2016**.
+
+Currently by default, this script will use [Azure Marketplace - Bing Search API v2][azurebing], and the `BING_SEARCH_API_KEY` environment variable should be the [v2 key][azurebingkey] (from Azure Marketplace).
+
+Nevertheless, we strongly recommend that you use [Microsoft Cognitive Services - Bing Search API v5][cognitivebing] by setting `USE_BING_V5` to `true` in the environment that is using this script, and ensuring the `BING_SEARCH_API_KEY` is the [v5 key][cognitivebingkey] (from Cognitive Services).
+
+`USE_BING_V5` will not be necessary by 2017 when the v2 API is deprecated at end of life.
 
 
 ## Installation via NPM
@@ -32,10 +42,10 @@ See [`src/search.coffee`](src/search.coffee) for full documentation.
 Variable | Default | Description
 --- | --- | ---
 `GOOGLE_API_KEY` | N/A | A unique developer [API key](https://developers.google.com/custom-search/json-api/v1/introduction#identify_your_application_to_google_with_api_key) is required to use Google's Custom Search API
-`GOOGLE_CUSTOM_SEARCH` | N/A | The [Google Custom Search][gcse] engine [identifier](https://cse.google.com/cse/all) (the `cx` portion of the custom search engine URL)
-`BING_SEARCH_API_KEY` | N/A | The [primary account key](https://datamarket.azure.com/dataset/explore/bing/searchweb) for performing [Bing Search API][bse] queries
+`GOOGLE_CUSTOM_SEARCH` | N/A | The [Google Custom Search][googlesearch] engine [identifier](https://cse.google.com/cse/all) (the `cx` portion of the custom search engine URL)
+`BING_SEARCH_API_KEY` | N/A | The [API key][cognitivebingkey] for performing [Bing Search API][cognitivebing] queries
 
-### [Google Custom Search][gcse]
+### [Google Custom Search][googlesearch]
 
 The Google Custom Search command listener will not be registered if neither `GOOGLE_API_KEY` nor `GOOGLE_CUSTOM_SEARCH` environment variables are defined.
 
@@ -59,17 +69,31 @@ The Google Custom Search command listener will not be registered if neither `GOO
     export GOOGLE_CUSTOM_SEARCH="ENGINE ID HERE"
     ```
 
-### [Bing Search API][bse]
+### [Azure Marketplace - Bing Search API v2][azurebing]
 
 The Bing Search API command listener will not be registered if `BING_SEARCH_API_KEY` is not defined.
 
 1. Visit https://datamarket.azure.com/dataset/bing/searchweb
 2. Subscribe for a _"Bing Search API – Web Results Only"_ package / plan (free works fine)
-3. [Obtain][bsekey] the primary account key (located at the top of the page under _"Show"_)
+3. [Obtain][azurebingkey] the primary account key (located at the top of the page under _"Show"_)
 4. Export the API key:
 
     ```bash
     export BING_SEARCH_API_KEY="API KEY HERE"
+    ```
+
+### [Microsoft Cognitive Services - Bing Search API v5][azurebing]
+
+The Bing Search API command listener will not be registered if `BING_SEARCH_API_KEY` is not defined.
+
+1. Visit https://www.microsoft.com/cognitive-services/en-us/subscriptions?productId=/products/56ec2de6bca1df083495c610
+2. Subscribe for a _"Bing Web Search"_ package / plan (free works fine)
+3. [Obtain][cognitivebingkey] the API key (located in the _"Keys"_ column; click _"Show"_)
+4. Export the API key:
+
+    ```bash
+    export BING_SEARCH_API_KEY="API KEY HERE"
+    export USE_BING_V5="true"
     ```
 
 
@@ -91,6 +115,8 @@ hubot>> ...
 ```
 
 
-[gcse]: https://cse.google.com/
-[bse]: https://datamarket.azure.com/dataset/bing/searchweb
-[bsekey]: https://datamarket.azure.com/dataset/explore/bing/searchweb
+[googlesearch]: https://cse.google.com/
+[azurebing]: https://datamarket.azure.com/dataset/bing/searchweb
+[azurebingkey]: https://datamarket.azure.com/dataset/explore/bing/searchweb
+[cognitivebing]: https://azure.microsoft.com/en-gb/services/cognitive-services/search/
+[cognitivebingkey]: https://www.microsoft.com/cognitive-services/en-US/subscriptions

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.4",
   "author": "Ian Lai <os@fyianlai.com>",
   "license": "MIT",
-  "keywords": "hubot, hubot-scripts, search engine, google, duckduckgo, bing, web search",
+  "keywords": "hubot, hubot-scripts, search engine, google, microsoft, cognitive services, bing, web search, custom search",
   "repository": {
     "type": "git",
     "url": "git://github.com/ClaudeBot/hubot-search.git"


### PR DESCRIPTION
This API will replace the existing Azure Marketplace
Bing Search API v2 by the end of the year (approx. 6 months).

To use:
- Set `BING_SEARCH_API_KEY` to a v5 key (from Cognitive
  Services)
- Set `USE_BING_V5` to `true` (otherwise it will default
  to v2)

TODO:
- Deprecation notice / warning for existing users
- Update docs
