### PR TITLE
Add environment variable to configure number of results returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Variable | Default | Description
 `GOOGLE_API_KEY` | N/A | A unique developer [API key](https://developers.google.com/custom-search/json-api/v1/introduction#identify_your_application_to_google_with_api_key) is required to use Google's Custom Search API
 `GOOGLE_CUSTOM_SEARCH` | N/A | The [Google Custom Search][googlesearch] engine [identifier](https://cse.google.com/cse/all) (the `cx` portion of the custom search engine URL)
 `BING_SEARCH_API_KEY` | N/A | The [API key][cognitivebingkey] for performing [Bing Search API][cognitivebing] queries
+`MAX_SEARCH_RESULTS` | 5 | The number of search results to return
 
 ### [Google Custom Search][googlesearch]
 
@@ -101,8 +102,8 @@ The Bing Search API command listener will not be registered if `BING_SEARCH_API_
 
 Command | Listener ID | Description
 --- | --- | ---
-hubot `<search|google>` `query` | `search.google` | Queries Google Custom Search for `query`, and returns the first 5 results
-hubot bing `query` | `search.bing` | Queries Bing Search API for `query`, and returns the first 5 results
+hubot `<search|google>` `query` | `search.google` | Queries Google Custom Search for `query`, and returns the first `MAX_SEARCH_RESULTS` results
+hubot bing `query` | `search.bing` | Queries Bing Search API for `query`, and returns the first `MAX_SEARCH_RESULTS` results
 
 
 ## Sample Interaction

--- a/src/search.coffee
+++ b/src/search.coffee
@@ -24,6 +24,7 @@ GOOGLE_API_KEY = process.env.GOOGLE_API_KEY
 GOOGLE_CUSTOM_SEARCH = process.env.GOOGLE_CUSTOM_SEARCH
 BING_SEARCH_API_KEY = process.env.BING_SEARCH_API_KEY
 USE_BING_V5 = process.env.USE_BING_V5
+MAX_RESULTS = process.env.MAX_SEARCH_RESULTS or 5
 
 DEF_SERVER_ERROR = "I'm unable to process your request at this time due to a server error. Please try again later."
 
@@ -66,7 +67,7 @@ class GoogleSearch extends ISearch
         params =
             key: GOOGLE_API_KEY
             cx: GOOGLE_CUSTOM_SEARCH
-            num: 5
+            num: MAX_RESULTS
             q: query
         @robot.http("https://www.googleapis.com/customsearch/v1")
             .header("content-type", "application/json")
@@ -91,7 +92,7 @@ class BingSearch extends ISearch
             auth: "#{BING_SEARCH_API_KEY}:#{BING_SEARCH_API_KEY}"
         params =
             $format: "json"
-            $top: 5
+            $top: MAX_RESULTS
             Query: "'#{query}'"
         # @robot.logger.debug "hubot-search: Bing Search API v2 params : #{params}"
         @robot.http("https://api.datamarket.azure.com/Bing/SearchWeb/v1/Web", opts)
@@ -114,7 +115,7 @@ class BingSearchV5 extends ISearch
         @robot.logger.info "hubot-search: using Microsoft Cognitive Services - Bing Search API v5 (Web only)"
         params =
             q: query
-            count: 5
+            count: MAX_RESULTS
         @robot.http("https://api.cognitive.microsoft.com/bing/v5.0/search")
             .header("content-type", "application/json")
             .header("Ocp-Apim-Subscription-Key", BING_SEARCH_API_KEY)


### PR DESCRIPTION
@mrcaron, I've made some changes to your original PR #3 to ignore the changes to the Travis badge.

Let me know if this is OK 👍 

---

Using an environment variable, you can now set the max results
instead of hardcoding it at 5.

If `MAX_SEARCH_RESULTS` is not set, it will default to 5.